### PR TITLE
Thumbnail 컴포넌트 제작

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  /* mockup 이미지 삽입을 위한 config */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'picsum.photos',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/shared/config/image.ts
+++ b/src/shared/config/image.ts
@@ -1,0 +1,5 @@
+export const THUMBNAIL_SIZE_MAP = {
+  sm: '72px',
+  md: '96px',
+  lg: '128px',
+} as const;

--- a/src/shared/ui/component/thumbnail.tsx
+++ b/src/shared/ui/component/thumbnail.tsx
@@ -1,0 +1,30 @@
+import Image from 'next/image';
+import { tv } from 'tailwind-variants';
+import { THUMBNAIL_SIZE_MAP } from '@/shared/config/image';
+
+const thumbnail = tv({
+  base: 'relative overflow-hidden bg-gray-100 rounded-md',
+  variants: {
+    size: {
+      sm: 'w-16 h-16',
+      md: 'w-24 h-24',
+      lg: 'w-32 h-32',
+    },
+  },
+});
+
+interface Props {
+  size: 'sm' | 'md' | 'lg';
+  src: string;
+  alt: string;
+}
+
+const Thumbnail = ({ size, src, alt }: Props) => {
+  return (
+    <div className={thumbnail({ size })}>
+      <Image src={src} alt={alt} fill className='object-cover' sizes={THUMBNAIL_SIZE_MAP[size]} />
+    </div>
+  );
+};
+
+export default Thumbnail;


### PR DESCRIPTION
closes #33 

### 작업 미리보기
<img width="264" height="351" alt="스크린샷 2025-10-02 오전 12 59 01" src="https://github.com/user-attachments/assets/a55a6d4c-4f94-442d-bf04-d64d19531e9c" />

#### 사용위치
- product-card
- 채팅 내 사진 전송 시 thumbnail