### PR TITLE
[feat] auction-engagement 컴포넌트 생성

### DIFF
--- a/src/app/auction/[id]/page.tsx
+++ b/src/app/auction/[id]/page.tsx
@@ -1,5 +1,5 @@
+import Carousel from '@widgets/carousel/ui/carousel';
 import AuctionDetailHeader from '@widgets/header/ui/auction-detail';
-import Carousel from '@/widgets/carousel/ui/carousel';
 
 const AuctionDetail = () => {
   return (

--- a/src/entities/product/model/constants.ts
+++ b/src/entities/product/model/constants.ts
@@ -16,5 +16,5 @@ export const PRODUCT_DUMMY: Product = {
   endDate: '2025.12.31',
   currentPrice: '999,999,999',
   favorites: 8,
-  view: 63,
+  views: 63,
 };

--- a/src/entities/product/model/constants.ts
+++ b/src/entities/product/model/constants.ts
@@ -6,6 +6,15 @@ export const TYPE_TO_SIZE = {
 export const PRODUCT_DUMMY: Product = {
   title: '이것은 제가 직접 공수해온 겁니다 이 바보들아 내거야 다',
   thumbnail: 'https://picsum.photos/200/200',
+  images: [
+    'https://picsum.photos/seed/auctionA/500/300',
+    'https://picsum.photos/seed/auctionB/500/300',
+    'https://picsum.photos/seed/auctionC/500/300',
+    'https://picsum.photos/seed/auctionD/500/300',
+    'https://picsum.photos/seed/auctionE/500/300',
+  ],
   endDate: '2025.12.31',
   currentPrice: '999,999,999',
+  favorites: 8,
+  view: 63,
 };

--- a/src/entities/product/model/type.d.ts
+++ b/src/entities/product/model/type.d.ts
@@ -7,5 +7,5 @@ interface Product {
   endDate: string;
   currentPrice: string;
   favorites: number;
-  view: number;
+  views: number;
 }

--- a/src/entities/product/model/type.d.ts
+++ b/src/entities/product/model/type.d.ts
@@ -3,6 +3,9 @@
 interface Product {
   title: string;
   thumbnail: string;
+  images: string[];
   endDate: string;
   currentPrice: string;
+  favorites: number;
+  view: number;
 }

--- a/src/entities/product/ui/product-engagement.tsx
+++ b/src/entities/product/ui/product-engagement.tsx
@@ -1,0 +1,28 @@
+import { Eye, Heart } from 'lucide-react';
+import { cn } from 'tailwind-variants/lite';
+
+type EngagementType = 'views' | 'favorites';
+
+interface EngagementProps {
+  type: EngagementType;
+  counts: number;
+}
+
+const EngagementMaps = {
+  views: { title: '조회수', icon: Eye },
+  favorites: { title: '관심', icon: Heart },
+};
+
+const ProductEngagement = ({ type, counts }: EngagementProps) => {
+  const IconComponent = EngagementMaps[type].icon;
+
+  return (
+    <p className={cn(`text-body flex gap-1 items-center text-gray-500`)}>
+      <IconComponent className='size-4' />
+      <strong className='mr-1'>{EngagementMaps[type].title}</strong>
+      {counts}
+    </p>
+  );
+};
+
+export default ProductEngagement;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,11 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@component/*": ["./src/shared/ui/component/*"],
-      "@widgets/*": ["./src/widgets/*"]
+      "@widgets/*": ["./src/widgets/*"],
+      "@features/*": ["./src/features"],
+      "@entities/*": ["./src/entities/*"],
+      "@shared/*": ["./src/shared"],
+      "@component/*": ["./src/shared/ui/component/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "tailwind.config.ts"],


### PR DESCRIPTION
<img width="172" height="30" alt="image" src="https://github.com/user-attachments/assets/bd5f7305-9661-4aeb-bfab-ca472b76bb93" />

- [x] type: favorites, view props로 지정
- [x] product의 counts를 props로 전달
- [x] type에 따른 engagement의 title, icon 매핑