### PR TITLE
[feat] profile-card 컴포넌트 생성

### DIFF
--- a/src/app/auction/[id]/page.tsx
+++ b/src/app/auction/[id]/page.tsx
@@ -5,7 +5,8 @@ import { ProfileCard } from '@/entities/user/ui/profile-card';
 import ProductOverview from '@/widgets/product/product-overview';
 
 const AuctionDetail = () => {
-  const { title, id, status, views, favorites, startDate, endDate, uuid } = PRODUCT_DUMMY;
+  const { title, id, status, views, favorites, startDate, endDate, uuid, tradeLocation } =
+    PRODUCT_DUMMY;
 
   return (
     <>
@@ -19,6 +20,7 @@ const AuctionDetail = () => {
           favorites={favorites}
           startDate={startDate}
           endDate={endDate}
+          tradeLocation={tradeLocation}
         />
         <ProfileCard uuid={uuid} />
         <section>detail contents: text & bid-status-table</section>

--- a/src/app/auction/[id]/page.tsx
+++ b/src/app/auction/[id]/page.tsx
@@ -1,16 +1,17 @@
 import Carousel from '@widgets/carousel/ui/carousel';
 import AuctionDetailHeader from '@widgets/header/ui/auction-detail';
 import { PRODUCT_DUMMY } from '@/entities/product/model/constants';
+import { ProfileCard } from '@/entities/user/ui/profile-card';
 import ProductOverview from '@/widgets/product/product-overview';
 
 const AuctionDetail = () => {
-  const { title, id, status, views, favorites, startDate, endDate } = PRODUCT_DUMMY;
+  const { title, id, status, views, favorites, startDate, endDate, uuid } = PRODUCT_DUMMY;
 
   return (
     <>
       <AuctionDetailHeader />
       <Carousel auctionId={id} name={title} />
-      <article>
+      <article className='space-y-1'>
         <ProductOverview
           status={status}
           title={title}
@@ -19,7 +20,7 @@ const AuctionDetail = () => {
           startDate={startDate}
           endDate={endDate}
         />
-        <section>profile card</section>
+        <ProfileCard uuid={uuid} />
         <section>detail contents: text & bid-status-table</section>
         <footer>bid-banner</footer>
       </article>

--- a/src/entities/product/model/constants.ts
+++ b/src/entities/product/model/constants.ts
@@ -28,4 +28,5 @@ export const PRODUCT_DUMMY: Product = {
   favorites: 8,
   views: 63,
   status: 'CLOSED',
+  tradeLocation: '서울특별시 강남구 역삼동',
 };

--- a/src/entities/product/model/constants.ts
+++ b/src/entities/product/model/constants.ts
@@ -14,6 +14,7 @@ export const PRODUCTCARD_DUMMY: ProductCard = {
 
 export const PRODUCT_DUMMY: Product = {
   id: '1234',
+  uuid: 'user-1234',
   title: '이것은 제가 직접 공수해온 겁니다 이 바보들아 내거야 다',
   thumbnail: 'https://picsum.photos/200/200',
   images: [

--- a/src/entities/product/model/type.d.ts
+++ b/src/entities/product/model/type.d.ts
@@ -9,6 +9,7 @@ interface ProductCard {
 
 interface Product {
   id: string;
+  uuid: string;
   title: string;
   thumbnail: string;
   images: string[];

--- a/src/entities/product/model/type.d.ts
+++ b/src/entities/product/model/type.d.ts
@@ -19,4 +19,5 @@ interface Product {
   favorites: number;
   views: number;
   status: AuctionStatus;
+  tradeLocation: string;
 }

--- a/src/entities/product/ui/product-engagement.tsx
+++ b/src/entities/product/ui/product-engagement.tsx
@@ -19,7 +19,7 @@ const ProductEngagement = ({ type, counts }: EngagementProps) => {
   return (
     <p className={cn(`text-body flex gap-1 items-center text-gray-500`)}>
       <IconComponent className='size-4' />
-      <strong className='mr-1'>{EngagementMaps[type].title}</strong>
+      <span className='mr-1'>{EngagementMaps[type].title}</span>
       {counts}
     </p>
   );

--- a/src/entities/user/lib/hooks/use-time-ago.ts
+++ b/src/entities/user/lib/hooks/use-time-ago.ts
@@ -1,0 +1,71 @@
+import { useState, useEffect } from 'react';
+
+// Date 객체를 받아 포맷팅된 문자열을 반환하는 헬퍼 함수
+const formatFullDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+
+  return `${year}. ${month}. ${day}. ${hours}:${minutes}`;
+};
+
+/**
+ * 주어진 ISO 타임스탬프로부터 현재까지의 시간을 조건에 따라 포맷팅하는 커스텀 훅.
+ */
+
+export const useTimeAgo = (isoTimestamp: string | null | undefined): string => {
+  const [timeAgo, setTimeAgo] = useState<string>('');
+
+  useEffect(() => {
+    // timestamp가 유효하지 않으면 아무것도 하지 않음
+    if (!isoTimestamp) return;
+
+    const calculateTimeAgo = () => {
+      const now = new Date();
+      const past = new Date(isoTimestamp);
+      const seconds = Math.floor((now.getTime() - past.getTime()) / 1000);
+
+      // 조건 1: 1분 이내 -> n초 전
+      if (seconds < 60) {
+        setTimeAgo(`${seconds}초 전`);
+        return;
+      }
+
+      const minutes = Math.floor(seconds / 60);
+      // 조건 2: 10분 이내 -> n분 전
+      if (minutes < 10) {
+        setTimeAgo(`${minutes}분 전`);
+        return;
+      }
+      // 조건 3: 59분 이내 -> n0분 전 (10분 단위로 내림)
+      if (minutes < 60) {
+        const tensOfMinutes = Math.floor(minutes / 10) * 10;
+        setTimeAgo(`${tensOfMinutes}분 전`);
+        return;
+      }
+
+      const hours = Math.floor(seconds / 3600);
+      // 조건 4: 24시간 이내 -> n시간 전
+      if (hours < 24) {
+        setTimeAgo(`${hours}시간 전`);
+        return;
+      }
+
+      const days = Math.floor(seconds / 86400);
+      // 조건 5: 1일 이상 8일 미만 -> n일 전
+      if (days < 8) {
+        setTimeAgo(`${days}일 전`);
+        return;
+      }
+
+      // 조건 6: 8일 이상 -> YYYY. MM. DD. HH:mm
+      setTimeAgo(`마지막 접속일 ${formatFullDate(past)}`);
+    };
+
+    calculateTimeAgo();
+  }, [isoTimestamp]);
+
+  return timeAgo;
+};

--- a/src/entities/user/model/constants.ts
+++ b/src/entities/user/model/constants.ts
@@ -1,0 +1,18 @@
+export const PROFILECARD_DUMMY: Profilecard = {
+  uuid: 'user-1234',
+  nickName: '아띠',
+  img: 'https://picsum.photos/id/582/300/400',
+  is_online: true,
+};
+
+export const PROFILECARD_DUMMY2: Profilecard = {
+  uuid: 'user-5678',
+  nickName: '코야',
+  last_seen_at: '2025-10-11T08:33:04Z',
+};
+
+export const PROFILECARD_DUMMY3: Profilecard = {
+  uuid: 'user-90190',
+  nickName: '기니',
+  last_seen_at: '2025-10-11T02:33:04Z',
+};

--- a/src/entities/user/model/type.d.ts
+++ b/src/entities/user/model/type.d.ts
@@ -1,0 +1,7 @@
+interface Profilecard {
+  uuid: string;
+  nickName: string;
+  img?: string;
+  is_online?: boolean;
+  last_seen_at?: string;
+}

--- a/src/entities/user/ui/profile-card/chat-button.tsx
+++ b/src/entities/user/ui/profile-card/chat-button.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import Button from '@/shared/ui/component/button';
+
+const ChatButton = ({ uuid }: { uuid: string }) => {
+  const createChatHandler = (uuid: string) => {
+    console.log('create new chat room with', uuid);
+  };
+
+  return (
+    <Button size={'sm'} className='font-regular shrink-0' onClick={() => createChatHandler(uuid)}>
+      문의하기
+    </Button>
+  );
+};
+
+export default ChatButton;

--- a/src/entities/user/ui/profile-card/index.ts
+++ b/src/entities/user/ui/profile-card/index.ts
@@ -1,0 +1,1 @@
+export { default as ProfileCard } from './profile-card';

--- a/src/entities/user/ui/profile-card/profile-card.tsx
+++ b/src/entities/user/ui/profile-card/profile-card.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { PROFILECARD_DUMMY } from '@entities/user/model/constants';
+import { UserPresence } from '@entities/user/ui/user-presence';
+import Avatar from '@shared/ui/component/avatar';
+import ChatButton from './chat-button';
+
+interface ProfileCardProps {
+  uuid: string;
+}
+
+const ProfileCard = ({ uuid }: ProfileCardProps) => {
+  // Todo: uuid로 user 정보 fetch
+  const pathname = usePathname();
+  const { nickName, img, is_online, last_seen_at } = PROFILECARD_DUMMY;
+
+  // Todo: 쿠키에 저장된 인증된 정보로 비교
+  const isAuthor = uuid === 'user-90190';
+  const isAuction = pathname.includes('auction');
+
+  const goProfileByUuidHandler = () => {
+    console.log('connect router for go to /profile/[uuid]', uuid);
+  };
+
+  return (
+    <section className='flex w-full bg-background p-4 items-center'>
+      <button
+        type='button'
+        onClick={goProfileByUuidHandler}
+        className='flex items-center gap-3 w-full text-left'
+      >
+        <Avatar size={'basic'} img={img ? { url: `${img}`, alt: `${nickName} 프로필` } : null} />
+        <div>
+          <p className='text-body font-bold'>{nickName}</p>
+          {!isAuthor && (
+            <UserPresence status={typeof is_online === 'boolean' ? is_online : last_seen_at} />
+          )}
+        </div>
+      </button>
+      {isAuction && !isAuthor && <ChatButton uuid={uuid} />}
+    </section>
+  );
+};
+
+export default ProfileCard;

--- a/src/entities/user/ui/user-presence/index.ts
+++ b/src/entities/user/ui/user-presence/index.ts
@@ -1,0 +1,1 @@
+export { default as UserPresence } from './user-presence.tsx';

--- a/src/entities/user/ui/user-presence/user-presence.tsx.tsx
+++ b/src/entities/user/ui/user-presence/user-presence.tsx.tsx
@@ -1,0 +1,24 @@
+import { cn } from 'tailwind-variants/lite';
+import { useTimeAgo } from '../../lib/hooks/use-time-ago';
+
+interface PresenceProps {
+  status: boolean | string | undefined;
+}
+
+const UserPresence = ({ status }: PresenceProps) => {
+  const timeAgo = useTimeAgo(status as string);
+
+  return (
+    <>
+      {typeof status !== 'string' ? (
+        <div className={cn(`flex items-center text-caption font-medium text-gray-500 gap-1`)}>
+          <i className={cn(`block size-2 bg-positive-900 rounded-full`)} />
+          <p>접속 중</p>
+        </div>
+      ) : (
+        <p className={cn(`text-caption font-medium text-gray-500`)}>{timeAgo}</p>
+      )}
+    </>
+  );
+};
+export default UserPresence;

--- a/src/shared/ui/component/avatar.tsx
+++ b/src/shared/ui/component/avatar.tsx
@@ -10,7 +10,7 @@ interface AvatarProps {
 }
 
 const AvatarStyle = tv({
-  base: 'aspect-square overflow-hidden rounded-full',
+  base: 'aspect-square overflow-hidden rounded-full bg-gray-50',
   variants: { size: { basic: 'w-10', sm: 'w-7', lg: 'w-30' } },
 });
 

--- a/src/shared/ui/component/avatar.tsx
+++ b/src/shared/ui/component/avatar.tsx
@@ -14,7 +14,7 @@ const AvatarStyle = tv({
   variants: { size: { basic: 'w-10', sm: 'w-7', lg: 'w-30' } },
 });
 
-const Avatar = ({ size, img = null }: AvatarProps) => {
+const Avatar = ({ size, img }: AvatarProps) => {
   return (
     <div className={`${AvatarStyle({ size: size })}`}>
       {!img && <AvatarDefault />}

--- a/src/shared/ui/component/avatar.tsx
+++ b/src/shared/ui/component/avatar.tsx
@@ -10,7 +10,7 @@ interface AvatarProps {
 }
 
 const AvatarStyle = tv({
-  base: 'aspect-square',
+  base: 'aspect-square overflow-hidden rounded-full',
   variants: { size: { basic: 'w-10', sm: 'w-7', lg: 'w-30' } },
 });
 
@@ -18,7 +18,7 @@ const Avatar = ({ size, img = null }: AvatarProps) => {
   return (
     <div className={`${AvatarStyle({ size: size })}`}>
       {!img && <AvatarDefault />}
-      {img && <img src={img.url} alt={img.alt} />}
+      {img && <img className='w-full h-full cover' src={img.url} alt={img.alt} />}
     </div>
   );
 };

--- a/src/widgets/product/product-overview.tsx
+++ b/src/widgets/product/product-overview.tsx
@@ -11,6 +11,7 @@ interface ProductOverviewProps {
   favorites: number;
   startDate: string;
   endDate: string;
+  tradeLocation: string;
 }
 
 const ProductOverview = ({
@@ -20,13 +21,18 @@ const ProductOverview = ({
   favorites,
   startDate,
   endDate,
+  tradeLocation,
 }: ProductOverviewProps) => {
+  const SplitedLocation = tradeLocation.split(' ').filter((item, idx) => idx !== 0);
+  const resultLocation = SplitedLocation.join(' ');
+
   return (
     <section className='bg-background p-4'>
       <ProductStatusBadge status={status} />
       <h3 className='text-subtitle font-bold text-ellipsis line-clamp-2 my-3'>{title}</h3>
       <div className='flex items-center w-full justify-between mb-6'>
-        <div className='flex item-center gap-4'>
+        <div className='flex item-center gap-3'>
+          <p className='text-body text-gray-500'>{resultLocation}</p>
           <ProductEngagement type={'views'} counts={views} />
           <ProductEngagement type={'favorites'} counts={favorites} />
         </div>


### PR DESCRIPTION
- [x] ~ 분전과 같은 시간 계산을 위한 timeAgo 커스텀 훅 생성
- [x] user-presence 컴포넌트 생성: 사용자의 접속 정보 확인
- [x] profile-card 컴포넌트 퍼블리싱: case - auction & !isAuthor, auction & Author
- [x] avatar 컴포넌트 img 스타일링 추가
- [x] product-overview 거래 장소 표시 추가

*Todo action*
route: /profile/[uuid] 접속, params[uuid] === user.uuid 상황에서 profile-card 컴포넌트를 호출할 때
profile-card 내의 button onclick= handle/profile/[uuid]/edit 로 이동